### PR TITLE
修复在Flutter 2.2.3中的问题，更新后台API接口地址。

### DIFF
--- a/lib/constant/app_urls.dart
+++ b/lib/constant/app_urls.dart
@@ -1,7 +1,7 @@
 
 class AppUrls{
 //  static const String BASE_URL='http://192.168.190.98:8082/wx'; //测试服务
-  static const String BASE_URL = 'http://120.25.226.11:8080/mall-app/wx';//线上服务
+  static const String BASE_URL = 'http://192.168.50.206:8080/wx';//线上服务
   static const String HOME_URL=BASE_URL+'/home/index';//首页数据
   static const String BANNER_URL = BASE_URL + '/home/banner'; //获取首页banner图
   static const String CATEGORY_URL = BASE_URL + '/home/categories'; //获取首页分类

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -44,7 +44,7 @@ class MallApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      locale: DevicePreview.of(context).locale,
+      locale: DevicePreview.locale(context),
       // <--- /!\ Add the locale
       builder: DevicePreview.appBuilder,
       // <--- /!\ Add the builder

--- a/lib/ui/page/home/tab_mine_page.dart
+++ b/lib/ui/page/home/tab_mine_page.dart
@@ -31,7 +31,7 @@ class _TabMinePageState extends State<TabMinePage> {
       return Stack(children: [
         Container(
             height: ScreenUtil().setHeight(AppDimens.DIMENS_600) +
-                MediaQuery.of(context).padding.top,
+                MediaQuery.maybeOf(context).padding.top,
             decoration: BoxDecoration(
                 gradient: LinearGradient(
                     colors: [AppColors.COLOR_FFB24E, AppColors.COLOR_FF5722]),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 2.0.0
+version: 2.2.3
 
 environment:
   sdk: ">=2.7.0 <3.0.0"
@@ -41,12 +41,12 @@ dependencies:
   flutter_widget_from_html_core: ^0.4.1
   tuple: ^1.0.3
   flutter_html: ^0.10.4
-  city_pickers: ^0.1.30
+  city_pickers: ^1.0.1
   flutter_slidable: ^0.5.7
   flutter_webview_plugin: ^0.3.11
   common_utils: ^1.2.1
   event_bus: ^1.1.1
-  device_preview: ^0.4.8
+  device_preview: ^0.6.2-beta
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
MediaQuery.of 在新版Flutter中已经舍弃，所以需要升级相关调用；此外，后台默认的接口已没有/mall-app/的路径。